### PR TITLE
Removed migration dynamic timestamp

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -22,7 +22,7 @@ class PermissionServiceProvider extends ServiceProvider
 
         if (!class_exists('CreatePermissionTables')) {
             // Publish the migration
-            $timestamp = date('Y_m_d_His', time());
+            $timestamp = '2016_12_19_122301';
             $this->publishes([
                 __DIR__.'/../resources/migrations/create_permission_tables.php.stub' => $this->app->databasePath().'/migrations/'.$timestamp.'_create_permission_tables.php',
             ], 'migrations');


### PR DESCRIPTION
When using this package with a deploy service like envoyer.io, it tries to rerun this migration because a new timestamp is set.
A static timestamp resolves this issue.